### PR TITLE
Document that encoding MAC in BLE_MAC_LIST is not mandatory.

### DIFF
--- a/INSTALLwDockerfile.md
+++ b/INSTALLwDockerfile.md
@@ -68,7 +68,7 @@ iv. Download docker-compose.yml and stack.env from the github repository:
    ```
 v. You will need to edit docker-compose.yml. Change the line `image: "iainbullock/tesla_ble_mqtt:latest"` to `image: "tesla_ble_mqtt:latest"`
 <br /><br />
-vi. Update the environment variables in stack.env according to your needs. As a minimum enter the VIN of your car, and the connection details for your MQTT server. If you want BLE detection enter the BLE MAC address of the car (see below for instructions on how to find this TODO):
+vi. Update the environment variables in stack.env according to your needs. As a minimum enter the VIN of your car, and the connection details for your MQTT server. BLE MAC address of the car for BLE detection can be deduced automatically from the vehicule VIN, but you can fill `BLE_MAC_LIST`:
 ```shell
 # Mandatory; if multiple VINs separate with , or white space
 #


### PR DESCRIPTION
I am not sure at 100% but #38 and #87 permit to not encode the BLE MAC.

At least I never encoded the MAC and it found out at first run, and now it say something like: `Found BLE_MAC:74:AA:AA:AA:AA:AA in /share/tesla_ble_mqtt/XP7YAAAA0AA000000_macaddr; adding to BLE_MAC_LIST`

Not sure what should be the wording, maybe it is recommended to encode it???