### PR TITLE
Match comment with regex check

### DIFF
--- a/stack.env
+++ b/stack.env
@@ -1,4 +1,4 @@
-# Mandatory; if multiple VINs separate with , or white space
+# Mandatory; if multiple VINs separate with |
 #
 VIN_LIST=
 


### PR DESCRIPTION
I just tried to set up everything with 3 VINs but always got a
`VIN_LIST:VIN123,VIN234,VIN345 is not compliant, please check this setting`
Also using whitespaces did not work out. After checking libproduct.sh I realized that | is the required separator for VIN_LIST according to VIN_PATTERN.