### PR TITLE
fix: presence detection can not be disabled

### DIFF
--- a/libproduct.sh
+++ b/libproduct.sh
@@ -12,7 +12,7 @@ function validateEnvVars() {
     exitOnError=1
   fi
 
-  if ! echo $PRESENCE_DETECTION_LOOP_DELAY | grep -Eq "$INT1PLUS_PATTERN"; then
+  if ! echo $PRESENCE_DETECTION_LOOP_DELAY | grep -Eq "$INT0PLUS_PATTERN"; then
     log_fatal "Fatal; PRESENCE_DETECTION_LOOP_DELAY:$PRESENCE_DETECTION_LOOP_DELAY is not compliant, please check this setting"
     exitOnError=1
   fi


### PR DESCRIPTION
Since I have multiple vehicles that can be quite close to the RPi in my garage I'm using the Tesla Fleet API integration in Home Assistant to detect which vehicle is at home and connected to the charger.
tesla_ble_mqtt_core has support to disable the presence detection but in here is a check that makes it impossible to disable it actually.
https://github.com/tesla-local-control/tesla_ble_mqtt_core/blob/f1c0f86ff8b016b1d35344ee40d1a6744b8ac955/run.sh#L114